### PR TITLE
changing var names not to reference dkneipp and fix README

### DIFF
--- a/terraform/output-local.tf
+++ b/terraform/output-local.tf
@@ -9,6 +9,6 @@ resource "local_file" "lambda_role_arn" {
 }
 
 resource "local_file" "s3_bucket_name" {
-  content  = aws_s3_bucket.dkneipp_sagemaker.id
+  content  = aws_s3_bucket.bucket_sagemaker.id
   filename = "bucket-name.txt"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,5 +7,5 @@ output "lambda_role_arn" {
 }
 
 output "s3_bucket_name" {
-  value = aws_s3_bucket.dkneipp_sagemaker.id
+  value = aws_s3_bucket.bucket_sagemaker.id
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,9 +1,9 @@
 
-resource "aws_s3_bucket" "dkneipp_sagemaker" {
+resource "aws_s3_bucket" "bucket_sagemaker" {
   bucket = var.bucket_name
 }
 
-resource "aws_s3_bucket_acl" "dkneipp_sagemaker" {
-  bucket = aws_s3_bucket.dkneipp_sagemaker.id
+resource "aws_s3_bucket_acl" "bucket_sagemaker" {
+  bucket = aws_s3_bucket.bucket_sagemaker.id
   acl    = "private"
 }


### PR DESCRIPTION
README file has a typo that took me a while to see while copying and pasting
also removing the reference for `dkneipp` on the terraform files 